### PR TITLE
Fix build on linux/clang

### DIFF
--- a/src/Object/Store/mkStore.h
+++ b/src/Object/Store/mkStore.h
@@ -112,8 +112,8 @@ namespace mk
 
 		using Typed<T_Array, void, Stock>::cls;
 
-		inline T_Array* self() { return this->as<T_Array>(); }
-		inline const T_Array* self() const { return this->as<T_Array>(); }
+		inline T_Array* self() { return this->template as<T_Array>(); }
+		inline const T_Array* self() const { return this->template as<T_Array>(); }
 
 	protected:
 		Type* mType;

--- a/src/Object/Threading/mkLocklessQueue.h
+++ b/src/Object/Threading/mkLocklessQueue.h
@@ -4,34 +4,35 @@
 * @version 1.14
 *
 * @section LICENSE
-* 
-* This source file is part of OgreOggSound, an OpenAL wrapper library for   
-* use with the Ogre Rendering Engine.										 
-*                                                                           
-* Copyright 2010 Ian Stangoe 
-*                                                                           
-* OgreOggSound is free software: you can redistribute it and/or modify		  
-* it under the terms of the GNU Lesser General Public License as published	 
-* by the Free Software Foundation, either version 3 of the License, or		 
-* (at your option) any later version.										 
-*																			 
-* OgreOggSound is distributed in the hope that it will be useful,			 
-* but WITHOUT ANY WARRANTY; without even the implied warranty of			 
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the			 
-* GNU Lesser General Public License for more details.						 
-*																			 
-* You should have received a copy of the GNU Lesser General Public License	 
-* along with OgreOggSound.  If not, see <http://www.gnu.org/licenses/>.	 
+*
+* This source file is part of OgreOggSound, an OpenAL wrapper library for
+* use with the Ogre Rendering Engine.
+*
+* Copyright 2010 Ian Stangoe
+*
+* OgreOggSound is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* OgreOggSound is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with OgreOggSound.  If not, see <http://www.gnu.org/licenses/>.
 *
 * @section DESCRIPTION
-* 
+*
 * Template class for a lockless queue system to pass items from one thread to another.
-* Only 1 thread can push and 1 thread can pop it. 
+* Only 1 thread can push and 1 thread can pop it.
 * All credit goes to: Lf3THn4D
 */
 
 #ifndef MK_LOCKLESSQUEUE_H
 #define MK_LOCKLESSQUEUE_H
+#include <cstddef>
 
 namespace mk
 {

--- a/src/Object/Util/mkStat.h
+++ b/src/Object/Util/mkStat.h
@@ -138,7 +138,7 @@ namespace mk
 			: TStat<T>(base, min, max)
 		{}
 
-		const string& name() { return T_Name; }
+		const string name() { return T_Name; }
 	};
 
 	template <class T>

--- a/src/Object/mkObjectConfig.h
+++ b/src/Object/mkObjectConfig.h
@@ -20,12 +20,32 @@
 #define _M_ // Mutable Attribute
 #define _O_ // Owned Attribute
 #define _N_ // Nested Attribute
-#define _P_ // Pool Attribute 
+#define _P_ // Pool Attribute
 
-#if defined OBJECT_EXPORT
-	#define MK_OBJECT_EXPORT __declspec(dllexport)
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef OBJECT_EXPORT
+    #ifdef __GNUC__
+      #define MK_OBJECT_EXPORT __attribute__ ((dllexport))
+    #else
+      #define MK_OBJECT_EXPORT __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define MK_OBJECT_EXPORT __attribute__ ((dllimport))
+    #else
+      #define MK_OBJECT_EXPORT __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #endif
+  #define DLL_LOCAL
 #else
-	#define MK_OBJECT_EXPORT __declspec(dllimport)
+  #if __GNUC__ >= 4
+    #define MK_OBJECT_EXPORT __attribute__ ((visibility ("default")))
+    #define DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define MK_OBJECT_EXPORT
+    #define DLL_LOCAL
+  #endif
 #endif
 
 #define MK_FUNC_EXPORT __cdecl

--- a/src/Object/mkRef.h
+++ b/src/Object/mkRef.h
@@ -123,11 +123,7 @@ namespace mk
 	//T* cast() const { return upcast<T>(mObject); }
 
 	template <class T>
-	struct MakeRef {
-        static unique_ptr<Ref> make(typename Pass<T>::forward val) {
-            return make_unique<Any<T>>(std::forward<typename Pass<T>::forward>(val));
-        };
-    };
+	struct MakeRef { static unique_ptr<Ref> make(typename Pass<T>::forward val) { return make_unique<Any<T>>(std::forward<typename Pass<T>::forward>(val)); }; };
 
 	template <class T>
 	struct MakeRef<T*> { static unique_ptr<Ref> make(T* obj) { return obj ? make_unique<Ref>(obj, T::cls()) : make_unique<Ref>(T::cls()); }; };

--- a/src/Object/mkRef.h
+++ b/src/Object/mkRef.h
@@ -45,7 +45,7 @@ namespace mk
 
 		template <class T>
 		inline Any<T>* any() { return static_cast<Any<T>*>(this); }
-		
+
 		template <class T>
 		inline const Any<T>* any() const { return static_cast<const Any<T>*>(this); }
 
@@ -123,7 +123,11 @@ namespace mk
 	//T* cast() const { return upcast<T>(mObject); }
 
 	template <class T>
-	struct MakeRef { static unique_ptr<Ref> make(typename Pass<T>::forward val) { return make_unique<Any<T>>(std::forward<typename Pass<T>::forward>(val)); }; };
+	struct MakeRef {
+        static unique_ptr<Ref> make(typename Pass<T>::forward val) {
+            return make_unique<Any<T>>(std::forward<typename Pass<T>::forward>(val));
+        };
+    };
 
 	template <class T>
 	struct MakeRef<T*> { static unique_ptr<Ref> make(T* obj) { return obj ? make_unique<Ref>(obj, T::cls()) : make_unique<Ref>(T::cls()); }; };

--- a/src/Object/mkTyped.cpp
+++ b/src/Object/mkTyped.cpp
@@ -24,5 +24,4 @@ namespace mk
 	template class MK_OBJECT_EXPORT Typed<std::vector<Object*>>;
 
 	template class MK_OBJECT_EXPORT Typed<Array<Object>>;
-	template class MK_OBJECT_EXPORT StoreObserver<Object>;
 }

--- a/src/Ui/Form/mkForm.cpp
+++ b/src/Ui/Form/mkForm.cpp
@@ -86,7 +86,7 @@ namespace mk
 
 	Form* Form::append(unique_ptr<Form> form)
 	{
-		return this->insert(std::move(form), this->last()); 
+		return this->insert(std::move(form), this->last());
 	}
 
 	unique_ptr<Form> Form::release(size_t pos)
@@ -95,7 +95,7 @@ namespace mk
 			mContents.at(pos)->widget()->detach();
 		return mContents.release(pos);
 	}
-	
+
 	void Form::remove(size_t index)
 	{
 		mContents.at(index)->destroy();
@@ -109,7 +109,7 @@ namespace mk
 			return toString(mIndex);
 	}
 
-	void Form::setIndex(size_t index)
+	void Form::setIndex(Id index)
 	{
 		mIndex = index;
 		this->updateIndex();
@@ -125,7 +125,7 @@ namespace mk
 	void Form::updateIndex()
 	{
 		mFullIndex = concatIndex();
-		
+
  		for(auto& pt : mContents.store())
 			pt->as<Form>()->updateIndex();
 	}
@@ -145,7 +145,7 @@ namespace mk
 	{
 		this->destroy();
 		/*mDestroy = true;
-		
+
 		size_t pos = mParent->last();
 		if(pos && pos != mIndex)
 			mParent->mContents.move(mIndex, pos);*/

--- a/src/Ui/Form/mkForm.h
+++ b/src/Ui/Form/mkForm.h
@@ -119,7 +119,7 @@ namespace mk
 		template <class T, class... Args>
 		inline T* makeappend(Args&&... args)
 		{
-			return this->append(make_unique<T>(std::forward<Args>(args)...))->as<T>();
+			return this->append(make_unique<T>(std::forward<Args>(args)...))->template as<T>();
 		}
 
 	public:

--- a/src/Ui/Widget/mkSheet.h
+++ b/src/Ui/Widget/mkSheet.h
@@ -47,19 +47,19 @@ namespace mk
 		template <class T, class... Args>
 		inline T* vmakeappend(Args&&... args)
 		{
-			return this->vappend(make_unique<T>(std::forward<Args>(args)...))->as<T>();
+			return this->vappend(make_unique<T>(std::forward<Args>(args)...))->template as<T>();
 		}
 
 		template <class T, class... Args>
 		inline T* makeappend(Args&&... args)
 		{
-			return this->append(make_unique<T>(std::forward<Args>(args)...))->as<T>();
+			return this->append(make_unique<T>(std::forward<Args>(args)...))->template as<T>();
 		}
 
 		template <class T, class... Args>
 		inline T* makeinsert(size_t index, Args&&... args)
 		{
-			return this->insert(make_unique<T>(std::forward<Args>(args)...), index)->as<T>();
+			return this->insert(make_unique<T>(std::forward<Args>(args)...), index)->template as<T>();
 		}
 
 	protected:

--- a/src/Ui/mkUiConfig.h
+++ b/src/Ui/mkUiConfig.h
@@ -28,10 +28,29 @@
 
 #include <Object/mkObjectConfig.h>
 
-#if defined UI_EXPORT
-#define MK_UI_EXPORT __declspec(dllexport)
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef UI_EXPORT
+    #ifdef __GNUC__
+      #define MK_UI_EXPORT __attribute__ ((dllexport))
+    #else
+      #define MK_UI_EXPORT __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define MK_UI_EXPORT __attribute__ ((dllimport))
+    #else
+      #define MK_UI_EXPORT __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #endif
+  #define DLL_LOCAL
 #else
-#define MK_UI_EXPORT __declspec(dllimport) 
+  #if __GNUC__ >= 4
+    #define MK_UI_EXPORT __attribute__ ((visibility ("default")))
+    #define DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define MK_UI_EXPORT
+    #define DLL_LOCAL
+  #endif
 #endif
 
 #endif // MK_UICONFIG_H_INCLUDED

--- a/src/Ui/mkUiExample.cpp
+++ b/src/Ui/mkUiExample.cpp
@@ -66,12 +66,12 @@ namespace mk
 		current->makeappend<SliderFloat>("float input", Stat<float>(1.123f, 0.0f, 2.0f));
 		current->makeappend<SliderFloat>("log float", Stat<float>(0.f, 0.0f, 10.0f));
 		current->makeappend<SliderFloat>("signed log float", Stat<float>(0.f, -10.0f, 10.0f));
-		current->makeappend<SliderFloat>("unbound float", Stat<float>(123456789.0f, -FLT_MAX, FLT_MAX));
+		current->makeappend<SliderFloat>("unbound float", Stat<float>(123456789.0f, std::numeric_limits<float>::min(), std::numeric_limits<float>::max()));
 	}
 
 	void exampleApp()
 	{
-		unique_ptr<GlWindow> glwindow = make_unique<GlWindow>(1200, 800, "mk UiEditApp", "../Data/interface");
+		unique_ptr<GlWindow> glwindow = make_unique<GlWindow>(1200, 800, "mk UiEditApp", "./data");
 		glwindow->initContext();
 
 		UiWindow* uiwindow = glwindow->uiWindow();


### PR DESCRIPTION
- Fix calls to 'object->as' in template functions
- mkStat.h (TNamedStat.name): Return name by value rather than byref
- mkObjectConfig.h/mkUiConfig.h: Cross platform export macros
- mkUiExample.cpp: Use std::numeric_limits rather than FLT_MAX
