### PR TITLE
- Cmake fix to build the project on Windows with VS 2013

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,11 @@ add_definitions("-DUI_EXPORT")
 
 if (MSVC)
 	add_definitions("-D_CRT_SECURE_NO_WARNINGS")
+	include(CheckIncludeFiles)
+	CHECK_INCLUDE_FILES(dirent.h HAVE_DIRENT_API) #Check for dirent.h header in MSVC include directories
+	if (NOT HAVE_DIRENT_API)
+		message(FATAL_ERROR "MSVC has no support for Dirent API, please include the header manually. See: http://www.softagalleria.net/dirent.php")
+	endif()
 endif ()
 
 add_library(kiui SHARED ${SOURCE_FILES} ${HEADER_FILES})


### PR DESCRIPTION
As there is no built-in Dirent API on Windows, the project fails to build without providing the mentioned twin header. There could likely be better way/syntax to correct the error but that's me the Cmake noob..
