### PR TITLE
[CMake] Support for reading env var KIUI_STATIC for building static lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ language: cpp
 compiler:
   - gcc
   - clang
-    
+
+env:
+  - KIUI_STATIC=0
+  - KIUI_STATIC=1
+
 install:
   - sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,9 +46,24 @@ if (MSVC)
 	endif()
 endif ()
 
-option(${PROJECT_NAME}_STATIC "Build static lib instead dynamic one")
+if (DEFINED ENV{${PROJECT_NAME}_STATIC})
+	if ($ENV{${PROJECT_NAME}_STATIC})
+		message(STATUS "env variable ${PROJECT_NAME}_STATIC is set")
+		if (NOT DEFINED ${PROJECT_NAME}_STATIC)
+			# enable static build from env only on first config start
+			option(${PROJECT_NAME}_STATIC "Build static lib instead dynamic one" ON)
+		endif ()
+	endif ()
+endif()
+
+# if KIUI_STATIC env not set into 1 enable dynamic lib by default
+if (NOT DEFINED ${PROJECT_NAME}_STATIC)
+	option(${PROJECT_NAME}_STATIC "Build static lib instead dynamic one")
+endif ()
+
 set(LIB_TYPE SHARED)
 if (${PROJECT_NAME}_STATIC)
+	message(STATUS "Building kiui static lib")
 	set(LIB_TYPE STATIC)
 	if (CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 		#enable Position-independent code generation for static lib


### PR DESCRIPTION
- At the first run on generation step cmake reads KIUI_STATIC env variable
  and if and only if KIUI_STATIC=1 enables static library build (sets
  KIUI_STATIC CMake variable enabled). After that user can manually set
  KIUI_STATIC variable from cmake-gui without overwriting it by following
  generation steps
- Matrix builds in Travis for static and dynamic configs
